### PR TITLE
[FIX] Remove Warnings in List Component

### DIFF
--- a/src/components/List/Readme.md
+++ b/src/components/List/Readme.md
@@ -1,0 +1,12 @@
+React component example:
+
+```jsx
+const food = [
+  { key: '01', content: 'Pizza' },
+  { key: '02', content: 'Hamburguer' }
+];
+
+<List
+  items={food}
+/>
+```

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -16,7 +16,7 @@ const List = (props) => {
       {...props}
     >
       {props.items.map((item) => (
-        <Li key={item.id}>{item.content}</Li>
+        <Li key={item.key}>{item.content}</Li>
       ))}
     </Ul>
   )


### PR DESCRIPTION
The main goal is to remove the warnings related to key prop when using List Component.  
I replace **id** to **key** in order to avoid warnings in console and React mixing up the elements and mutate the incorrect one. 